### PR TITLE
Update PTG detect script to use input COCO file as processing guide

### DIFF
--- a/yolov7/detect_ptg.py
+++ b/yolov7/detect_ptg.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import argparse
 import random
@@ -8,6 +10,7 @@ import cv2
 from typing import List, Optional, Tuple, Union
 import warnings
 
+import click
 import ubelt as ub
 import numpy as np
 import numpy.typing as npt
@@ -18,6 +21,7 @@ from angel_system.data.medical.data_paths import GrabData
 # from angel_system.data.common.load_data import time_from_name
 # from angel_system.data.common.load_data import Re_order
 
+from ultralytics import YOLO
 from yolov7.models.yolo import Model as YoloModel
 from yolov7.models.experimental import attempt_load
 from yolov7.utils.general import check_img_size, non_max_suppression, scale_coords, xyxy2xywh, xywh2xyxy
@@ -29,18 +33,36 @@ import moviepy.video.io.ImageSequenceClip
 
 """
 
-python yolov7/detect_ptg.py --tasks m2 --split val --weights /data/PTG/medical/training/yolo_object_detector/train/m2_good_objects_only_no_hand_no_amputation_stump_hue/weights/best.pt --project /data/PTG/medical/training/yolo_object_detector/detect/ --name m2_good_objects_only_no_hand_no_amputation_stump_hue_v2 --device 0 --save-img --img-size 768 --conf-thres 0.1
+python yolov7/detect_ptg.py \
+--tasks m2 \
+--split val \
+--weights /data/PTG/medical/training/yolo_object_detector/train/m2_good_objects_only_no_hand_no_amputation_stump_hue/weights/best.pt \
+--project /data/PTG/medical/training/yolo_object_detector/detect/ \
+--name m2_good_objects_only_no_hand_no_amputation_stump_hue_v2 \
+--device 0 \
+--save-img \
+--img-size 768 \
+--conf-thres 0.1
 
 python yolov7/detect_ptg.py \
 --tasks m2 \
---split val --weights /data/PTG/medical/training/yolo_object_detector/train/m2_good_objects_only_no_hand_no_amputation_stump_hue/weights/best.pt \
+--split val \
+--weights /data/PTG/medical/training/yolo_object_detector/train/m2_good_objects_only_no_hand_no_amputation_stump_hue/weights/best.pt \
 --project /data/PTG/medical/training/yolo_object_detector/detect/ \
 --name m2_good_objects_only_no_hand_no_amputation_stump_hue_v2 --device 0 --save-img \
 --img-size 768 \ 
 --conf-thres 0.1
 
-
-python yolov7/detect_ptg.py --tasks m3 --split train --weights /data/PTG/medical/training/yolo_object_detector/train/m3_all_v16/weights/best.pt --project /data/PTG/medical/training/yolo_object_detector/detect/ --name m3_all --device 0 --save-img --img-size 768 --conf-thres 0.25 
+python yolov7/detect_ptg.py \
+--tasks m3 \
+--split train \
+--weights /data/PTG/medical/training/yolo_object_detector/train/m3_all_v16/weights/best.pt \
+--project /data/PTG/medical/training/yolo_object_detector/detect/ \
+--name m3_all \
+--device 0 \
+--save-img \
+--img-size 768 \
+--conf-thres 0.25
 
 """
 
@@ -237,82 +259,186 @@ def predict_image(
         return boxes, confs, classids
 
 
-def video_to_frames(video_path, save_path, video_name):
-    print(f"video path: {video_path}")
-    cap = cv2.VideoCapture(video_path)
-    frame_count = 0
-    # frame_rate = 1
-    success = True
-    num = 0
-    if not os.path.exists(save_path):
-        os.makedirs(save_path)
-    while (success):
-        success, frame = cap.read()
-        if success == True:
-            height, width, channels = frame.shape
-            # print(frame.shape)
-            file_name = f"{video_name}_{frame_count}.png"
-            # image_dict = {
-            #     "id": f"{index}{frame_count}",
-            #     "file_name": file_name,
-            #     "video_name": f"{video_name}",
-            #     "video_id": index,
-            #     "width": width,
-            #     "height": height,
-            # }
-            # coco_json["images"].append(image_dict)
-            # if frame_count % frame_rate == 0:
-                # cv2.imwrite(each_video_save_full_path + video_name + '/'+ "%06d.jpg" % num, frame)
-            cv2.imwrite(f"{save_path}/{file_name}", frame)
-            frame_count += 1
-                # image_dict["path"] = f"{dir_path}/{file_name}"
-                # num += 1
-
-        # frame_count = frame_count + 1
-    # print('Final frame:', num)
-    return
-
-def generate_images_gt(video_dir_path):
-
-    if os.path.isfile(video_dir_path):
-        from pathlib import Path
-
-        video_path = video_dir_path
-        video_name = os.path.basename(video_path).split(".")[0]
-        path = Path(video_path)
-        frames_save_path = f"{path.parent.absolute()}/{video_name}/images/"
-    else:
-        frames_save_path = f"{video_dir_path}/images/"
-        video_name = os.path.basename(video_dir_path)
-        video_path = f"{video_dir_path}/{video_name}.mp4"
-        gt_path = f"{video_dir_path}/{video_name}.skill_labels_by_frame.txt"
-
-    #todo: can add the GT by frame in this spot
-    video_to_frames(video_path=video_path, save_path=frames_save_path,
-                    video_name=video_name)
-
-
-    print(f"video path: {video_path}")
-
-    return frames_save_path
-
-def detect(opt):
-    """Run the model over a series of images
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "-i", "--input-coco-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help=(
+        "MS-COCO file specifying image files to perform object detection over. "
+        "Image and Video sections from this COCO file will be maintained in the "
+        "output COCO file."
+    ),
+    required=True,
+)
+@click.option(
+    "--img-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Optional override for the input COCO dataset bundle root. This is "
+        "necessary when the input COCO file uses relative paths and the COCO "
+        "file itself is not located in the bundle root directory."
+    ),
+)
+@click.option(
+    "-o", "--output-coco-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Output COCO file to write object detection results.",
+    required=True,
+)
+@click.option(
+    "--model-hands", "hand_model_ckpt",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Model checkpoint for the Yolo v8 hand detector.",
+    required=True,
+)
+@click.option(
+    "--model-objects", "objs_model_ckpt",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Model checkpoint for the Yolo v7 object detector.",
+    required=True,
+)
+@click.option(
+    "--model-device",
+    default="",
+    help="The CUDA device to use, i.e. '0' or '0,1,2,3' or 'cpu'."
+)
+@click.option(
+    "--img-size",
+    type=int,
+    default=1280,
+    help=(
+        "Data input size for object detection models. This should be a "
+        "multiple of the model's stride parameter."
+    )
+)
+@click.option(
+    "--no-trace",
+    is_flag=True,
+    help="Don't trace the Yolo v7 model.",
+)
+@click.option(
+    "--augment", "inference_augment",
+    is_flag=True,
+    help="Augment data during inferencing."
+)
+@click.option(
+    "--conf-thres",
+    type=float,
+    default=0.25,
+    help=(
+        "Object confidence threshold. Predicted objects with confidence less "
+        "than this will not be considered for output."
+    ),
+)
+@click.option(
+    "--iou-thres",
+    type=float,
+    default=0.45,
+    help=(
+        "IoU threshold used during NMS to filter out overlapping bounding "
+        "boxes."
+    ),
+)
+@click.option(
+    "--agnostic-nms",
+    is_flag=True,
+    help="Perform non-maximum suppression across all classes.",
+)
+@click.option(
+    "--save-img", "save_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Optionally enable the plotting of detections back to the image and "
+        "saving them out to disk, rooted in this directory. Only detections "
+        "with confidence above our configured threshold will be considered "
+        "for plotting."
+    )
+)
+@click.option(
+    "--top-k", "save_top_k",
+    type=int,
+    default=None,
+    help=(
+        "Optionally specify that only the top N confidence detections should "
+        "be saved to the output images. If this is not provided, all "
+        "detections with confidence above the --conf-thres value will be "
+        "plotted. This only applies to objects, not detected hands by that "
+        "respective model."
+    )
+)
+@click.option(
+    "--save-vid",
+    is_flag=True,
+    help=(
+        "Optionally enable the creation of an MP4 video from the images "
+        "rendered due to --save-img. This option only has an effect if the "
+        "--save-img option is provided. The video file will be save next to "
+        "the directory into which component images are saved."
+    )
+)
+def detect_v2(
+    input_coco_file: Path,
+    img_root: Optional[Path],
+    output_coco_file: Path,
+    hand_model_ckpt: Path,
+    objs_model_ckpt: Path,
+    model_device: str,
+    img_size: int,
+    no_trace: bool,
+    inference_augment: bool,
+    conf_thres: float,
+    iou_thres: float,
+    agnostic_nms: bool,
+    save_dir: Optional[Path],
+    save_top_k: Optional[int],
+    save_vid: bool,
+) -> None:
     """
-    save_path = f"{opt.project}/{opt.name}"
-    Path(save_path).mkdir(parents=True, exist_ok=True)
+    Updated version of object detection script for use in generating object
+    detection results based on an input COCO file's video/image specifications.
+
+    Expected use-case: generate object detections for video frames (images)
+    that we have activity classification truth for.
+
+    Output categories in the COCO file generated by this tool will **not**
+    include a "background" category (assumed to be a possible output of the
+    input model).
+    Non-background model classes will be assigned IDs starting with 0.
+
+    \b
+    Example:
+        python3 python-tpl/yolov7/yolov7/detect_ptg.py \\
+            -i ~/data/darpa-ptg/bbn_data/lab_data-working/m2_tourniquet/positive/3_tourns_122023/activity_truth.coco.json \\
+            -o ~/data/darpa-ptg/tcn_training_example/train-object_detections.coco.json \\
+            --model-hands ./model_files/object_detector/hands_model.pt \\
+            --model-objects ./model_files/object_detector/m2_det.pt \\
+            --model-device 0 \\
+            --img-size 768 \\
+            --save-img ./det-debug-imgs \\
+            --top-k 4
+    """
+    # Load the guiding COCO dataset.
+    guiding_dset = kwcoco.CocoDataset(input_coco_file, bundle_dpath=img_root)
+
+    # Prevent overwriting an existing file. These are expensive to compute so
+    # we don't want to mess that up.
+    if output_coco_file.is_file():
+        raise ValueError(
+            f"Output COCO file already exists, refusing to overwrite: "
+            f"{output_coco_file}"
+        )
+    output_coco_file.parent.mkdir(parents=True, exist_ok=True)
+    dset = kwcoco.CocoDataset()
+    dset.fpath = output_coco_file.as_posix()
 
     # Load model
-    device, model, stride, imgsz = load_model(opt.device, opt.weights, opt.img_size)
-    hand_model = YOLO(opt.hands_weights)
+    device, model, stride, imgsz = load_model(model_device, objs_model_ckpt, img_size)
+    hand_model = YOLO(hand_model_ckpt)
 
-    # print(f"hand_model: {hand_model.names}")
-    # print(f"image size opts: {opt.img_size}")
-    # print(f"image size: {imgsz}")
-    # exit()
-
-    if not opt.no_trace:
-        model = TracedModel(model, device, opt.img_size)
+    if not no_trace:
+        model = TracedModel(model, device, img_size)
 
     half = device.type != 'cpu'  # half precision only supported on CUDA
     if half:
@@ -323,383 +449,215 @@ def detect(opt):
     # print(names)
     colors = [[random.randint(0, 255) for _ in range(3)] for _ in names]
 
-    dset = kwcoco.CocoDataset()
+    # Port over the videos and images sections from the input dataset to the
+    # new one.
+    dset.dataset['videos'] = guiding_dset.dataset['videos']
+    dset.dataset['images'] = guiding_dset.dataset['images']
+    dset.index.build(dset)
+    # Equality can later be tested with:
+    #   guiding_dset.index.videos == dset.index.videos
+    #   guiding_dset.index.imgs == dset.index.imgs
 
     # Add categories
     for i, object_label in enumerate(names):
         if object_label == "background":
             continue
-        dset.add_category(name=object_label, id=i)
-
-    # print(f"dset cats: {dset.dataset['categories']}")
-    # hand_cid = dset.dataset['categories'][-1]['id'] + 1
-    # hand_cid = dset.add_category(name="hand")
-    left_hand_cid = dset.add_category(name="hand (left)")
-    right_hand_cid = dset.add_category(name="hand (right)")
+        dset.ensure_category(name=object_label, id=i)
+    # Inject categories for the hand-model additions.
+    left_hand_cid = dset.ensure_category(name="hand (left)")
+    right_hand_cid = dset.ensure_category(name="hand (right)")
     hands_cid_to_cat = {left_hand_cid: "hand (left)",
                         right_hand_cid: "hand (right)"}
-    # print(f"hand_cid: {hand_cid}")
-    # exit()
 
-    tasks_to_videos = data_loader(opt.tasks, data_type=opt.data_type, yaml_path=opt.data_gen_yaml)
+    for vid_id in ub.ProgIter(
+        dset.videos(),
+        desc="Processing videos",
+    ):
+        vid_obj = dset.index.videos[vid_id]  # noqa
+        vid_img_ids = dset.index.vidid_to_gids[vid_id]
 
-    for task in opt.tasks:
-        videos = tasks_to_videos[task]
-        for video in videos:
+        save_imgs_dir: Optional[Path] = None
+        if save_dir is not None:
+            save_imgs_dir = save_dir / Path(vid_obj["name"]).stem
+            assert not save_imgs_dir.is_file()
+            save_imgs_dir.mkdir(parents=True, exist_ok=True)
+        # If video saving is enable, this list should be populated with the
+        # filepaths to the image files that compose the frames of that video
+        vid_frames: List[str] = []
+        if save_vid:
+            # prepopulate "slots" for each frame.
+            vid_frames = [""] * len(vid_img_ids)
 
-            if os.path.isfile(video):
-                # from pathlib import Path
-                video_path = video
-                path = Path(video_path)
-                video_name = os.path.basename(video_path).split(".")[0]
-                frame_save_path = f"{path.parent.absolute()}/{video_name}/images/"
-            else:
-                video_name = os.path.basename(video)
-                frame_save_path = f"{video}/images/"
+        for img_id in ub.ProgIter(vid_img_ids, desc='Processing images'):
+            img_obj = dset.index.imgs[img_id]
 
-            images = glob.glob(f"{frame_save_path}/*.png")
-            if not images:
-                print(f"Images don't exist for video {video_name}. Generating images now")
-                frame_save_path = generate_images_gt(video)
-                images = glob.glob(f"{frame_save_path}/*.png")
-                # print(f"images: {len(images)}")
-            else:
-                print(f"Fetching images for {video_name} from {video}")
+            img_path = Path(dset.get_image_fpath(img_id))
+            assert img_path.is_file()
+            img0 = cv2.imread(img_path.as_posix())
+            height, width = img0.shape[:2]
+            gn = torch.tensor(img0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
 
-            # re-order images
-            ## TODO: assert if in order. if not re-order them.
-            images_tmp = [0 for _ in range(len(images))]
-            for image_path in images:
-                image_idx = image_path.split('/')[-1].split('.')[0].split('_')[-1]
-                images_tmp[int(image_idx)] = image_path
-                # print(image_idx)
-                # exit()
-            images = images_tmp
-            # print(f"images: {images[:10]}")
-            # print(f"images sorted: {images_tmp[:10]}")
-            # exit()
-            if opt.save_vid:
-                frames = [0 for x in range(len(images))]
+            object_preds = predict_image(
+                img0, device, model, stride, imgsz, half, inference_augment,
+                conf_thres, iou_thres, None, agnostic_nms,
+            )
+            object_boxes, object_confs, object_class_ids = object_preds
 
-            video_data = {
-                "name": video_name,
-                "task": task,
-            }
-            vid = dset.add_video(**video_data)
+            hands_preds = hand_model.predict(
+                source=img0,
+                conf=0.1,
+                imgsz=img_size,
+                device=device,
+                verbose=False,
+            )[0]  # returns list of length=num images, which is always 1 here.
 
-            if opt.save_img:
-                save_imgs_dir = f"{save_path}/images/{video_name}"
-                Path(save_imgs_dir).mkdir(parents=True, exist_ok=True)
+            top_k_preds = {}
+            for xyxy, conf, cls_id in zip(object_boxes, object_confs, object_class_ids):
+                # print(f"xyxy 1 : {type(xyxy)}")
+                norm_xywh = (xyxy2xywh(xyxy.view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
+                cxywh = [norm_xywh[0] * width, norm_xywh[1] * height,
+                         norm_xywh[2] * width, norm_xywh[3] * height]  # center xy, wh
+                xywh = [cxywh[0] - (cxywh[2] / 2), cxywh[1] - (cxywh[3] / 2),
+                        cxywh[2], cxywh[3]]
 
-            # images = Re_order(images, len(images))
-            for image_fn in ub.ProgIter(images, desc=f"images in {video_name}"):
-                fn = os.path.basename(image_fn)
-                img0 = cv2.imread(image_fn)  # BGR
-                assert img0 is not None, 'Image Not Found ' + image_fn
-                height, width = img0.shape[:2]
-
-                # frame_num, time = time_from_name(image_fn)
-                frame_num = fn.split('.')[0].split('_')[-1]
-                # print(f"frame num: {frame_num}, name: {fn}")
-                # exit()
-                # print(f"frame number: {frame_num}")
-                image = {
-                    "file_name": image_fn,
-                    "video_id": vid,
-                    "frame_index": frame_num,
-                    "width": width,
-                    "height": height,
+                # print(f"norm_xywh: {norm_xywh}")
+                # print(f"cxywh: {cxywh}")
+                # print(f"xywh: {xywh}")
+                ann = {
+                    "area": xywh[2] * xywh[3],
+                    "image_id": img_id,
+                    "category_id": cls_id,
+                    "bbox": xywh,
+                    "confidence": float(conf),
                 }
-                img_id = dset.add_image(**image)
+                dset.add_annotation(**ann)
 
-                gn = torch.tensor(img0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
+                # Optionally draw results
+                if save_dir is not None and save_top_k is None:  # Add bbox to image
+                    if cls_id != 0:
+                        label = f'{names[int(cls_id)]} {conf:.2f}'
+                        plot_one_box(xyxy, img0, label=label, color=colors[int(cls_id)], line_thickness=1)
 
-                preds = predict_image(
-                    img0, device, model, stride, imgsz, half, opt.augment,
-                    opt.conf_thres, opt.iou_thres, opt.classes, opt.agnostic_nms
-                )
+                # Determine top k results to draw later
+                if save_top_k is not None:
+                    cls_id_index = int(cls_id)
+                    k = {'conf': conf, "xyxy": xyxy}
 
-                # print(f"opt.img_size: {opt.img_size}")
+                    if cls_id_index not in top_k_preds.keys():
+                        top_k_preds[cls_id_index] = []
+                    if len(top_k_preds[cls_id_index]) < save_top_k:
+                        top_k_preds[cls_id_index].append(k)
+                    else:
+                        # Determine if we should add k
+                        min_k = min(enumerate(top_k_preds[cls_id_index]), key=lambda x: float(x[1]["conf"]))
 
-                hands_preds = hand_model.predict(
-                                        source=img0,
-                                        conf=0.1,
-                                        imgsz=opt.img_size,
-                                        device=device,
-                                        verbose=False)[0] # list of length=num images
-                objcet_boxes, object_confs, objects_classids = preds
-                # print(f"preds: {preds}")
-                # print(f"hands_preds: {hands_preds}")
-                # exit()
-
-                top_k_preds = {}
-                for xyxy, conf, cls_id in zip(objcet_boxes, object_confs, objects_classids):
-
-                    # print(f"xyxy 1 : {type(xyxy)}")
-                    norm_xywh = (xyxy2xywh(xyxy.view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
-                    cxywh = [norm_xywh[0] * width, norm_xywh[1] * height,
-                            norm_xywh[2] * width, norm_xywh[3] * height]  # center xy, wh
-                    xywh = [cxywh[0] - (cxywh[2] / 2), cxywh[1] - (cxywh[3] / 2),
-                            cxywh[2], cxywh[3]]
-
-                    # print(f"norm_xywh: {norm_xywh}")
-                    # print(f"cxywh: {cxywh}")
-                    # print(f"xywh: {xywh}")
-                    ann = {
-                        "area": xywh[2] * xywh[3],
-                        "image_id": img_id,
-                        "category_id": cls_id,
-                        "bbox": xywh,
-                        "confidence": float(conf),
-                    }
-                    dset.add_annotation(**ann)
-
-                    # Optionaly draw results
-                    if opt.save_img and not opt.top_k:  # Add bbox to image
-                        if cls_id != 0:
-                            label = f'{names[int(cls_id)]} {conf:.2f}'
-                            plot_one_box(xyxy, img0, label=label, color=colors[int(cls_id)], line_thickness=1)
-
-                    # Determine top k results to draw later
-                    if opt.top_k:
-                        cls_id_index = int(cls_id)
-                        k = {'conf': conf, "xyxy": xyxy}
-
-                        if cls_id_index not in top_k_preds.keys():
-                            top_k_preds[cls_id_index] = []
-                        if len(top_k_preds[cls_id_index]) < opt.top_k:
+                        if float(conf) > float(min_k[1]["conf"]):
+                            del top_k_preds[cls_id_index][min_k[0]]
                             top_k_preds[cls_id_index].append(k)
-                        else:
-                            # Determine if we should add k
-                            min_k = min(enumerate(top_k_preds[cls_id_index]), key=lambda x: float(x[1]["conf"]))
 
-                            if float(conf) > float(min_k[1]["conf"]):
-                                del top_k_preds[cls_id_index][min_k[0]]
-                                top_k_preds[cls_id_index].append(k)
+            # print(f"hand boxes: {len(hands_preds.boxes)}") right_hand_cid left_hand_cid
+            hand_centers = [center.xywh.tolist()[0][0] for center in hands_preds.boxes][:2]
+            hands_label = []
+            if len(hand_centers) == 2:
+                if hand_centers[0] > hand_centers[1]:
+                    hands_label.append(right_hand_cid)
+                    hands_label.append(left_hand_cid)
+                elif hand_centers[0] <= hand_centers[1]:
+                    hands_label.append(left_hand_cid)
+                    hands_label.append(right_hand_cid)
+            elif len(hand_centers) == 1:
+                if hand_centers[0] > width // 2:
+                    hands_label.append(right_hand_cid)
+                elif hand_centers[0] <= width // 2:
+                    hands_label.append(left_hand_cid)
 
-                # print(f"hand boxes: {len(hands_preds.boxes)}") right_hand_cid left_hand_cid
-                hand_centers = [center.xywh.tolist()[0][0] for center in hands_preds.boxes][:2]
-                hands_label = []
-                if len(hand_centers) == 2:
-                    if hand_centers[0] > hand_centers[1]:
-                        hands_label.append(right_hand_cid)
-                        hands_label.append(left_hand_cid)
-                    elif hand_centers[0] <= hand_centers[1]:
-                        hands_label.append(left_hand_cid)
-                        hands_label.append(right_hand_cid)
-                elif len(hand_centers) == 1:
-                    if hand_centers[0] > width//2:
-                        hands_label.append(right_hand_cid)
-                    elif hand_centers[0] <= width//2:
-                        hands_label.append(left_hand_cid)
+            # print(f"hand boxes: {hands_preds.boxes}")
+            # print(f"centers: {hand_centers}")
+            for bbox, hand_cid in zip(hands_preds.boxes, hands_label):
+                norm_xywh = bbox.xywhn.tolist()[0]
+                cxywh = [norm_xywh[0] * width, norm_xywh[1] * height,
+                         norm_xywh[2] * width, norm_xywh[3] * height]  # xy, wh
 
-                # print(f"hand boxes: {hands_preds.boxes}")
-                # print(f"centers: {hand_centers}")
-                for bbox, hand_cid in zip(hands_preds.boxes, hands_label):
-                    norm_xywh = bbox.xywhn.tolist()[0]
-                    cxywh = [norm_xywh[0] * width, norm_xywh[1] * height,
-                            norm_xywh[2] * width, norm_xywh[3] * height]  # xy, wh
+                xywh = [cxywh[0] - (cxywh[2] / 2), cxywh[1] - (cxywh[3] / 2),
+                        cxywh[2], cxywh[3]]
+                # xywh = [cxywh[0] - (cxywh[2] / 2), cxywh[1] - (cxywh[3] / 2),
+                #         cxywh[2], cxywh[3]]
+                # cls_id = int(bbox.cls.item())
+                # cls_name = names[hand_cid]
+                conf = bbox.conf.item()
 
-                    xywh = [cxywh[0] - (cxywh[2] / 2), cxywh[1] - (cxywh[3] / 2),
-                            cxywh[2], cxywh[3]]
-                    # xywh = [cxywh[0] - (cxywh[2] / 2), cxywh[1] - (cxywh[3] / 2),
-                    #         cxywh[2], cxywh[3]]
-                    # cls_id = int(bbox.cls.item())
-                    # cls_name = names[hand_cid]
-                    conf = bbox.conf.item()
+                # print(f"hand cxywh: {bbox.xywh}")
+                # print(f"hand xywh: {xywh}")
 
-
-                    # print(f"hand cxywh: {bbox.xywh}")
-                    # print(f"hand xywh: {xywh}")
-
-                    ann = {
+                ann = {
                     "area": xywh[2] * xywh[3],
                     "image_id": img_id,
                     "category_id": hand_cid,
                     "bbox": xywh,
                     "confidence": float(conf),
-                    }
-                    # exit()
-                    dset.add_annotation(**ann)
-                    if opt.save_img:
-                        label = f"{hands_cid_to_cat[hand_cid]}"
-                        # xywh_t = torch.tensor(xywh).view(1,4)
-                        xyxy_hand = bbox.xyxy.tolist()[0]
-                        # print(f"xywh_t: {xywh_t}")
-                        # print(f"xywh: {xywh}")
-                        # exit()
-                        # print(f"xywh 2: {type(xywh_t)}, {xywh_t.shape}")
-                        # xyxy_hand = xywh2xyxy(xywh_t).view(-1).tolist()
-                        # xyxy_hand = xywh2xyxy(xywh)
-                        # print(f"xyxy_hand: {xyxy_hand}")
-                        # print(f"img0: {img0.shape}")
-                        # print(f"xyxy: {xyxy}")
-                        plot_one_box(xyxy_hand, img0, label=label, color=[0, 0, 0], line_thickness=1)
-                # if len(hand_centers) == 1:
-                #     import matplotlib.pyplot as plt
-                #     image_show = dset.draw_image(gid=img_id)
-                #     plt.imshow(image_show)
-                #     plt.savefig('myfig.png')
-                #     exit()
-                # Only draw the top k detections per class
-                if opt.top_k and opt.save_img:
-                    for cls_id, preds in top_k_preds.items():
-                        if cls_id != 0:
-                            for pred in preds:
-                                conf = pred["conf"]
-                                xyxy = pred["xyxy"]
-                                label = f'{names[int(cls_id)]} {conf:.2f}'
-                                plot_one_box(xyxy, img0, label=label, color=colors[int(cls_id)], line_thickness=1)
-
-                if opt.save_img:
-                    cv2.imwrite(f"{save_imgs_dir}/{fn}", img0)
-                    if opt.save_vid:
-                        frames[int(frame_num)] = f"{save_imgs_dir}/{fn}"
-
-            if opt.save_vid:
-                video_save_path = f"{save_path}/{video_name}.mp4"
-                # video = cv2.VideoWriter(video_save_path, 0, 1, (width,height))
-
-                # print(f"frames: {frames}")
-                # for image_path in frames:
-                #     video.write(cv2.imread(image_path))
-
-                clip = moviepy.video.io.ImageSequenceClip.ImageSequenceClip(frames, fps=15)
-                clip.write_videofile(video_save_path)
-                # cv2.destroyAllWindows()
-                # video.release()
-
-                print(f"Saved video to: {video_save_path}")
+                }
                 # exit()
+                dset.add_annotation(**ann)
+                if save_dir is not None:
+                    label = f"{hands_cid_to_cat[hand_cid]}"
+                    # xywh_t = torch.tensor(xywh).view(1,4)
+                    xyxy_hand = bbox.xyxy.tolist()[0]
+                    # print(f"xywh_t: {xywh_t}")
+                    # print(f"xywh: {xywh}")
+                    # exit()
+                    # print(f"xywh 2: {type(xywh_t)}, {xywh_t.shape}")
+                    # xyxy_hand = xywh2xyxy(xywh_t).view(-1).tolist()
+                    # xyxy_hand = xywh2xyxy(xywh)
+                    # print(f"xyxy_hand: {xyxy_hand}")
+                    # print(f"img0: {img0.shape}")
+                    # print(f"xyxy: {xyxy}")
+                    plot_one_box(xyxy_hand, img0, label=label, color=[0, 0, 0], line_thickness=1)
+            # if len(hand_centers) == 1:
+            #     import matplotlib.pyplot as plt
+            #     image_show = dset.draw_image(gid=img_id)
+            #     plt.imshow(image_show)
+            #     plt.savefig('myfig.png')
+            #     exit()
+            # Only draw the top k detections per class
+            if save_dir is not None and save_top_k is not None:
+                for cls_id, preds in top_k_preds.items():
+                    if cls_id != 0:
+                        for pred in preds:
+                            conf = pred["conf"]
+                            xyxy = pred["xyxy"]
+                            label = f'{names[int(cls_id)]} {conf:.2f}'
+                            plot_one_box(xyxy, img0, label=label, color=colors[int(cls_id)], line_thickness=1)
 
-        # Save
-        dset.fpath = f"{save_path}/{opt.name}_all_obj_results.mscoco.json"
-        dset.dump(dset.fpath, newlines=True)
-        print(f"Saved predictions to {dset.fpath}")
+            if save_dir is not None:
+                save_path = (save_imgs_dir / img_path.name).as_posix()
+                if not cv2.imwrite(save_path, img0):
+                    raise RuntimeError(f"Failed to write debug image: {save_path}")
+                if save_vid:
+                    vid_frames[img_obj["frame_index"]] = save_path
 
+        if save_vid:
+            video_save_path = save_dir / f"{Path(vid_obj['name']).stem}-objects.mp4"
+            # video = cv2.VideoWriter(video_save_path, 0, 1, (width,height))
 
-def main():
-    parser = argparse.ArgumentParser()
+            # print(f"frames: {frames}")
+            # for image_path in frames:
+            #     video.write(cv2.imread(image_path))
 
-    parser.add_argument(
-        '--tasks',
-        type=str,
-        nargs='+',
-        default='coffee',
-        help='Dataset(s)'
-    )
-    parser.add_argument(
-        '--split',
-        type=str,
-        default='test',
-        help='Data split to run on'
-    )
-    parser.add_argument(
-        '--weights',
-        nargs='+',
-        type=str,
-        default='yolov7.pt',
-        help='model.pt path(s)'
-    )
-    parser.add_argument(
-        '--img-size',
-        type=int,
-        default=1280,
-        help='inference size (pixels)'
-    )
-    parser.add_argument(
-        '--conf-thres',
-        type=float,
-        default=0.25,
-        help='object confidence threshold'
-    )
-    parser.add_argument(
-        '--top-k',
-        type=int,
-        default=4,
-        help='draw the top k detections for each class'
-    )
-    parser.add_argument(
-        '--iou-thres',
-        type=float,
-        default=0.45,
-        help='IOU threshold for NMS'
-    )
-    parser.add_argument(
-        '--device',
-        default='',
-        help='cuda device, i.e. 0 or 0,1,2,3 or cpu'
-    )
-    parser.add_argument(
-        '--agnostic-nms',
-        action='store_true',
-        help='class-agnostic NMS'
-    )
-    parser.add_argument(
-        '--project',
-        default='runs/detect',
-        help='save results to project/name'
-    )
-    parser.add_argument(
-        '--name',
-        default='exp',
-        help='save results to project/name'
-    )
-    parser.add_argument(
-        '--no-trace',
-        action='store_true',
-        help='don`t trace model'
-    )
-    parser.add_argument(
-        '--augment',
-        action='store_true',
-        help='augmented inference'
-    )
-    parser.add_argument(
-        '--classes',
-        nargs='+',
-        type=int,
-        help='filter by class: --class 0, or --class 0 2 3'
-    )
-    parser.add_argument(
-        '--save-img',
-        action='store_true',
-        help='save results to *.png'
-    )
+            clip = moviepy.video.io.ImageSequenceClip.ImageSequenceClip(
+                vid_frames,
+                fps=vid_obj["framerate"]
+            )
+            clip.write_videofile(video_save_path.as_posix())
+            # cv2.destroyAllWindows()
+            # video.release()
 
-    parser.add_argument(
-        '--save-vid',
-        action='store_true',
-        help='save results to *.mp4'
-    )
+            print(f"Saved video to: {video_save_path}")
+            # exit()
 
-    parser.add_argument(
-        '--hands-weights',
-        nargs='+',
-        type=str,
-        default='/home/local/KHQ/peri.akiva/projects/Hands_v5/Model/weights/best.pt',
-        help='model.pt path(s)'
-    )
-
-    parser.add_argument(
-        '--data-type',
-        type=str,
-        default='pro',
-        help='pro=use professional data, lab=use lab data'
-    )
-
-    parser.add_argument(
-        '--data-gen-yaml',
-        type=str,
-        default='/home/local/KHQ/peri.akiva/projects/angel_system/config/data_generation/bbn_gyges.yaml',
-        help='Path to data generation yaml file'
-    )
-
-    opt = parser.parse_args()
-    print(opt)
-
-    detect(opt)
+    print(f"Saving output COCO file... ({output_coco_file})")
+    dset.dump(dset.fpath, newlines=True)
+    print(f"Saved output COCO file: {output_coco_file}")
 
 
 if __name__ == '__main__':
-    main()
+    detect_v2()

--- a/yolov7/detect_ptg.py
+++ b/yolov7/detect_ptg.py
@@ -483,7 +483,7 @@ def detect_v2(
                     "image_id": img_id,
                     "category_id": cls_id,
                     "bbox": xywh,
-                    "confidence": float(conf),
+                    "score": float(conf),
                 }
                 dset.add_annotation(**ann)
 


### PR DESCRIPTION
Updated CLI to use click as well as utilize an input COCO file for videos and images to process detections for, outputting COCO file of its own with detections results, maintaining congruent videos/images sections as was input (this can be asserted by downstream tools). The body of the detect function is more or less exactly the same, modulo some file path selection logic, removal of MP4 frame extraction (should be handled by an external process), and option variable renaming, amongst some other minor clean up items.